### PR TITLE
Track related refs in definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ groups into a single Swagger API description.
 
 ``` {.scala}
 scala> PathGroup.aggregate(apiInfo, List(PetsRoute, DinosRoute))
-res13: cats.data.ValidatedNel[com.timeout.docless.swagger.SchemaError,com.timeout.docless.swagger.APISchema] = Invalid(NonEmptyList(MissingDefinition(ResponseRef(TypeRef(Dino),/dinos/{id},Get))))
+res13: cats.data.ValidatedNel[com.timeout.docless.swagger.SchemaError,com.timeout.docless.swagger.APISchema] = Invalid(NonEmptyList(MissingDefinition(RefWithContext(TypeRef(Dino),ResponseContext(Get,/dinos/{id})))))
 ```
 
 The `aggregate` method will also verify that the schema definitions

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ groups into a single Swagger API description.
 
 ``` {.scala}
 scala> PathGroup.aggregate(apiInfo, List(PetsRoute, DinosRoute))
-res13: cats.data.ValidatedNel[com.timeout.docless.swagger.SchemaError,com.timeout.docless.swagger.APISchema] = Invalid(NonEmptyList(MissingDefinition(RefWithContext(TypeRef(Dino),ResponseContext(Get,/dinos/{id})))))
+res13: cats.data.ValidatedNel[com.timeout.docless.swagger.SchemaError,com.timeout.docless.swagger.APISchema] = Invalid(NonEmptyList(MissingDefinition(RefWithContext(TypeRef(Dino,None),ResponseContext(Get,/dinos/{id})))))
 ```
 
 The `aggregate` method will also verify that the schema definitions

--- a/src/main/scala/com/timeout/docless/encoders/Swagger.scala
+++ b/src/main/scala/com/timeout/docless/encoders/Swagger.scala
@@ -75,14 +75,14 @@ object Swagger {
   }
 
   implicit val schemaRefEnc = Encoder.instance[JsonSchema.Ref] {
-    case ArrayRef(id) =>
+    case ArrayRef(id, _) =>
       Json.obj(
         "type" -> Json.fromString("array"),
         "items" -> Json.obj(
           "$ref" -> Json.fromString(s"#/definitions/$id")
         )
       )
-    case TypeRef(id) =>
+    case TypeRef(id, _) =>
       Json.obj("$ref" -> Json.fromString(s"#/definitions/$id"))
   }
 

--- a/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
+++ b/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
@@ -31,7 +31,7 @@ trait JsonSchema[A] extends JsonSchema.HasRef {
   def asJsonRef: Json = asObjectRef.asJson
 
   lazy val definition: JsonSchema.Definition =
-    JsonSchema.Definition(id, asJson)
+    JsonSchema.Definition(id, relatedDefinitions.map(_.asRef), asJson)
 
   def definitions: Set[JsonSchema.Definition] =
     relatedDefinitions + definition
@@ -53,7 +53,8 @@ object JsonSchema
     def asArrayRef: Ref = ArrayRef(id)
   }
 
-  case class Definition(id: String, json: Json) extends HasRef
+  case class Definition(id: String, relatedRefs: Set[Ref], json: Json)
+      extends HasRef
 
   sealed trait Ref {
     def id: String

--- a/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
+++ b/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
@@ -1,5 +1,6 @@
 package com.timeout.docless.schema
 
+import com.timeout.docless.schema.JsonSchema.NamedDefinition
 import com.timeout.docless.swagger.Responses.Response
 import io.circe._
 import io.circe.syntax._
@@ -19,6 +20,9 @@ trait JsonSchema[A] extends JsonSchema.HasRef {
 
   def relatedDefinitions: Set[JsonSchema.Definition]
 
+  def fieldDefinitions: Set[JsonSchema.NamedDefinition] =
+    relatedDefinitions.collect { case d: NamedDefinition => d }
+
   def jsonObject: JsonObject
 
   def asJson: Json = jsonObject.asJson
@@ -30,8 +34,16 @@ trait JsonSchema[A] extends JsonSchema.HasRef {
 
   def asJsonRef: Json = asObjectRef.asJson
 
-  lazy val definition: JsonSchema.Definition =
-    JsonSchema.Definition(id, relatedDefinitions.map(_.asRef), asJson)
+  def namedDefinition(fieldName: String): NamedDefinition =
+    JsonSchema.NamedDefinition(
+      id,
+      fieldName,
+      relatedDefinitions.map(_.asRef),
+      asJson
+    )
+
+  lazy val definition: JsonSchema.UnnamedDefinition =
+    JsonSchema.UnnamedDefinition(id, relatedDefinitions.map(_.asRef), asJson)
 
   def definitions: Set[JsonSchema.Definition] =
     relatedDefinitions + definition
@@ -49,27 +61,43 @@ object JsonSchema
     with derive.CoprodInstances {
   trait HasRef {
     def id: String
-    def asRef: Ref      = TypeRef(id)
-    def asArrayRef: Ref = ArrayRef(id)
+    def asRef: Ref      = TypeRef(id, None)
+    def asArrayRef: Ref = ArrayRef(id, None)
   }
 
-  case class Definition(id: String, relatedRefs: Set[Ref], json: Json)
-      extends HasRef
+  sealed trait Definition extends HasRef {
+    def id: String
+    def json: Json
+    def relatedRefs: Set[Ref]
+  }
+
+  case class UnnamedDefinition(id: String, relatedRefs: Set[Ref], json: Json)
+      extends Definition
+
+  case class NamedDefinition(id: String,
+                             fieldName: String,
+                             relatedRefs: Set[Ref],
+                             json: Json)
+      extends Definition {
+    override def asRef      = TypeRef(id, Some(fieldName))
+    override def asArrayRef = ArrayRef(id, Some(fieldName))
+  }
 
   sealed trait Ref {
     def id: String
+    def fieldName: Option[String]
   }
 
-  case class TypeRef(id: String) extends Ref
+  case class TypeRef(id: String, fieldName: Option[String]) extends Ref
   object TypeRef {
-    def apply(definition: Definition): TypeRef = TypeRef(definition.id)
-    def apply(schema: JsonSchema[_]): TypeRef  = TypeRef(schema.id)
+    def apply(definition: Definition): TypeRef = TypeRef(definition.id, None)
+    def apply(schema: JsonSchema[_]): TypeRef  = TypeRef(schema.id, None)
   }
 
-  case class ArrayRef(id: String) extends Ref
+  case class ArrayRef(id: String, fieldName: Option[String]) extends Ref
   object ArrayRef {
-    def apply(definition: Definition): ArrayRef = ArrayRef(definition.id)
-    def apply(schema: JsonSchema[_]): ArrayRef  = ArrayRef(schema.id)
+    def apply(definition: Definition): ArrayRef = ArrayRef(definition.id, None)
+    def apply(schema: JsonSchema[_]): ArrayRef  = ArrayRef(schema.id, None)
   }
 
   trait PatternProperty[K] {

--- a/src/main/scala/com/timeout/docless/schema/derive/HListInstances.scala
+++ b/src/main/scala/com/timeout/docless/schema/derive/HListInstances.scala
@@ -18,15 +18,17 @@ trait HListInstances {
       lazyHSchema: Lazy[JsonSchema[H]],
       lazyTSchema: Lazy[JsonSchema[T]]
   ): JsonSchema[FieldType[K, H] :: T] = instanceAndRelated {
-    val hSchema = lazyHSchema.value
-    val tSchema = lazyTSchema.value
+    val fieldName = witness.value.name
+    val hSchema   = lazyHSchema.value
+    val tSchema   = lazyTSchema.value
     val (hValue, related) =
       if (hSchema.inline)
         hSchema.asJson -> tSchema.relatedDefinitions
       else
-        hSchema.asJsonRef -> (tSchema.relatedDefinitions + hSchema.definition)
+        hSchema.asJsonRef -> (tSchema.relatedDefinitions + hSchema
+          .namedDefinition(fieldName))
 
-    val hField  = witness.value.name -> hValue
+    val hField  = fieldName -> hValue
     val tFields = tSchema.jsonObject.toList
 
     JsonObject.fromIterable(hField :: tFields) -> related

--- a/src/main/scala/com/timeout/docless/swagger/PathGroup.scala
+++ b/src/main/scala/com/timeout/docless/swagger/PathGroup.scala
@@ -33,7 +33,7 @@ object PathGroup {
     val missingDefinitions =
       allDefs.foldMap { d =>
         d.relatedRefs.collect {
-          case r @ TypeRef(id) if !definedIds.exists(_ === id) =>
+          case r @ TypeRef(id, _) if !definedIds.exists(_ === id) =>
             SchemaError.missingDefinition(RefWithContext.definition(r, d))
         }
       }

--- a/src/main/scala/com/timeout/docless/swagger/RefWithContext.scala
+++ b/src/main/scala/com/timeout/docless/swagger/RefWithContext.scala
@@ -1,0 +1,28 @@
+package com.timeout.docless.swagger
+
+import com.timeout.docless.schema.JsonSchema.{Definition, Ref}
+
+object RefWithContext {
+  trait PathContext {
+    def path: String
+  }
+
+  sealed trait Context
+  case class DefinitionContext(definition: Definition) extends Context
+  case class ParamContext(param: String, path: String)
+      extends Context
+      with PathContext
+  case class ResponseContext(method: Method, path: String)
+      extends Context
+      with PathContext
+
+  def definition(ref: Ref, d: Definition) =
+    RefWithContext(ref, DefinitionContext(d))
+  def param(ref: Ref, param: String, path: String) =
+    RefWithContext(ref, ParamContext(param, path))
+  def response(ref: Ref, method: Method, path: String) =
+    RefWithContext(ref, ResponseContext(method, path))
+}
+
+import RefWithContext.Context
+case class RefWithContext(ref: Ref, context: Context)

--- a/src/main/scala/com/timeout/docless/swagger/SchemaError.scala
+++ b/src/main/scala/com/timeout/docless/swagger/SchemaError.scala
@@ -12,7 +12,8 @@ object SchemaError {
 
   implicit val mdShow: Show[SchemaError] = Show.show {
     case MissingDefinition(RefWithContext(r, DefinitionContext(d))) =>
-      s"${d.id}: cannot find a field definition for: '${r.id}'"
+      val fieldName = r.fieldName.fold("")(fld => s"(in field name: $fld)")
+      s"${d.id}: cannot find a definition for '${r.id}' $fieldName"
     case MissingDefinition(RefWithContext(r, ParamContext(param, path))) =>
       s"$path: cannot find definition '${r.id}' for parameter name '$param'"
     case MissingDefinition(RefWithContext(r, ResponseContext(method, path))) =>

--- a/src/main/scala/com/timeout/docless/swagger/SchemaError.scala
+++ b/src/main/scala/com/timeout/docless/swagger/SchemaError.scala
@@ -1,7 +1,7 @@
 package com.timeout.docless.swagger
 
 import cats.Show
-import com.timeout.docless.swagger.Path.{ParamRef, RefWithContext, ResponseRef}
+import RefWithContext._
 
 sealed trait SchemaError
 
@@ -11,9 +11,11 @@ object SchemaError {
     MissingDefinition(ctx)
 
   implicit val mdShow: Show[SchemaError] = Show.show {
-    case MissingDefinition(ParamRef(r, path, param)) =>
+    case MissingDefinition(RefWithContext(r, DefinitionContext(d))) =>
+      s"${d.id}: cannot find a field definition for: '${r.id}'"
+    case MissingDefinition(RefWithContext(r, ParamContext(param, path))) =>
       s"$path: cannot find definition '${r.id}' for parameter name '$param'"
-    case MissingDefinition(ResponseRef(r, path, method)) =>
+    case MissingDefinition(RefWithContext(r, ResponseContext(method, path))) =>
       s"$path: cannot find response definition '${r.id}' for method '${method.entryName}'"
   }
 }

--- a/src/test/scala/com/timeout/docless/schema/JsonSchemaTest.scala
+++ b/src/test/scala/com/timeout/docless/schema/JsonSchemaTest.scala
@@ -111,7 +111,7 @@ class JsonSchemaTest extends FreeSpec {
           """.stripMargin) should ===(Right(schema.asJson))
 
       schema.id should ===(id[Nested])
-      schema.relatedDefinitions should ===(Set(fs.definition))
+      schema.relatedDefinitions should ===(Set(fs.namedDefinition("foo")))
     }
 
     "with types extending enumeratum.EnumEntry" - {
@@ -175,18 +175,18 @@ class JsonSchemaTest extends FreeSpec {
 
       "provides JSON definitions of the coproduct" in {
         implicit val fs: JsonSchema[Foo] = fooSchema
-        val schema                       = JsonSchema.deriveFor[ADT]
-        val ySchema                      = JsonSchema.deriveFor[A]
-        val zSchema                      = JsonSchema.deriveFor[B]
 
-        val z1Schema = JsonSchema.deriveFor[C]
+        val schema  = JsonSchema.deriveFor[ADT]
+        val aSchema = JsonSchema.deriveFor[A]
+        val bSchema = JsonSchema.deriveFor[B]
+        val cSchema = JsonSchema.deriveFor[C]
 
         schema.relatedDefinitions should ===(
           Set(
-            ySchema.definition,
-            zSchema.definition,
-            z1Schema.definition,
-            fooSchema.definition
+            aSchema.definition,
+            bSchema.definition,
+            cSchema.definition,
+            fooSchema.namedDefinition("foo")
           )
         )
       }

--- a/src/test/scala/com/timeout/docless/swagger/PathGroupTest.scala
+++ b/src/test/scala/com/timeout/docless/swagger/PathGroupTest.scala
@@ -4,29 +4,29 @@ import org.scalatest.{FreeSpec, Inside, Matchers}
 import cats.data.NonEmptyList
 import cats.data.Validated
 import SchemaError._
+import com.timeout.docless.schema.JsonSchema
 import com.timeout.docless.schema.JsonSchema._
 import com.timeout.docless.swagger.Method._
-import com.timeout.docless.swagger.Path._
 
 class PathGroupTest extends FreeSpec with Matchers {
   "PathGroup" - {
     val petstore = PetstoreSchema()
     val pet      = PetstoreSchema.Schemas.pet
 
-    val paths     = Path("example") :: petstore.paths.get.toList
+    val paths     = Path("/example") :: petstore.paths.get.toList
     val defs      = petstore.definitions.get.toList
     val defsNoPet = defs.filterNot(_.id === pet.id)
     val params    = petstore.parameters.get.toList
 
     val group1          = PathGroup(paths, defs, params)
-    val group2          = PathGroup(List(Path("extra")), Nil, Nil)
+    val group2          = PathGroup(List(Path("/extra")), Nil, Nil)
     val groupMissingErr = PathGroup(paths, defsNoPet, params)
 
     def err(path: String, m: Method, f: Definition => Ref): SchemaError =
-      missingDefinition(ResponseRef(f(pet.definition), path, m))
+      missingDefinition(RefWithContext.response(f(pet.definition), m, path))
 
     "aggregate" - {
-      "when some definitions are missing" - {
+      "when some top level definitions are missing" - {
         "returns the missing refs" in {
           PathGroup.aggregate(petstore.info, List(groupMissingErr)) should ===(
             Validated.invalid[NonEmptyList[SchemaError], APISchema](
@@ -35,6 +35,37 @@ class PathGroupTest extends FreeSpec with Matchers {
                 err("/pets", Post, TypeRef.apply),
                 err("/pets/{id}", Get, TypeRef.apply),
                 err("/pets/{id}", Delete, TypeRef.apply)
+              )
+            )
+          )
+        }
+      }
+      "when some nested definitions are missing" - {
+        val info = Info("example")
+        case class Nested(name: String)
+        case class TopLevel(nested: Nested)
+
+        val schema = JsonSchema.deriveFor[TopLevel]
+        val nested = schema.relatedDefinitions.head
+
+        val paths = List(
+          "/example".Post(
+            Operation('_, "...")
+              .withParams(BodyParameter(schema = Some(schema.asRef)))
+          )
+        )
+
+        val withNested    = PathGroup(paths, schema.definitions.toList, Nil)
+        val withoutNested = PathGroup(paths, List(schema.definition), Nil)
+
+        "returns the missing refs" in {
+          PathGroup.aggregate(info, List(withNested)).isValid shouldBe true
+          PathGroup.aggregate(info, List(withoutNested)) should ===(
+            Validated.invalid[NonEmptyList[SchemaError], APISchema](
+              NonEmptyList.of(
+                MissingDefinition(
+                  RefWithContext.definition(nested.asRef, schema.definition)
+                )
               )
             )
           )


### PR DESCRIPTION
So far, the validations performed as part of the `PathGroup.aggregate` were only checking that all the top-level definitions reference in responses and body parameters were present. This PR introduces a new schema error (`MissingDefinition`) aimed at covering cases where nested field definitions are omitted. In order to make this possible, `JsonSchema.Definition` has been refactored into a sealed trait, allowing for both named definitions (for case class fields) and unneamed ones (for coproducts).