### PR TITLE
Do not always inline option schemas

### DIFF
--- a/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
+++ b/src/main/scala/com/timeout/docless/schema/JsonSchema.scala
@@ -34,7 +34,7 @@ trait JsonSchema[A] extends JsonSchema.HasRef {
 
   def asJsonRef: Json = asObjectRef.asJson
 
-  def namedDefinition(fieldName: String): NamedDefinition =
+  def NamedDefinition(fieldName: String): NamedDefinition =
     JsonSchema.NamedDefinition(
       id,
       fieldName,
@@ -119,6 +119,16 @@ object JsonSchema
       obj: => JsonObject
   )(implicit tag: ru.WeakTypeTag[A]): JsonSchema[A] =
     new JsonSchema[A] {
+      override def id                 = tag.tpe.typeSymbol.fullName
+      override def inline             = false
+      override def jsonObject         = obj
+      override def relatedDefinitions = Set.empty
+    }
+
+   def functorInstance[F[_],A](
+      obj: => JsonObject
+  )(implicit tag: ru.WeakTypeTag[A]): JsonSchema[F[A]] =
+    new JsonSchema[F[A]] {
       override def id                 = tag.tpe.typeSymbol.fullName
       override def inline             = false
       override def jsonObject         = obj

--- a/src/main/scala/com/timeout/docless/schema/Primitives.scala
+++ b/src/main/scala/com/timeout/docless/schema/Primitives.scala
@@ -2,9 +2,10 @@ package com.timeout.docless.schema
 
 import java.time.{LocalDate, LocalDateTime}
 
-import com.timeout.docless.schema.JsonSchema.{inlineInstance, PatternProperty}
+import com.timeout.docless.schema.JsonSchema._
 import io.circe._
 import io.circe.syntax._
+import scala.reflect.runtime.{universe => ru}
 
 trait Primitives {
   implicit val boolSchema: JsonSchema[Boolean] =
@@ -81,8 +82,9 @@ trait Primitives {
     )
   }
 
-  implicit def optSchema[A: JsonSchema]: JsonSchema[Option[A]] =
-    inlineInstance[Option[A]](implicitly[JsonSchema[A]].jsonObject)
+  implicit def optSchema[A](implicit ev: JsonSchema[A], tag: ru.WeakTypeTag[A]): JsonSchema[Option[A]] =
+    if (ev.inline) inlineInstance[Option[A]](ev.jsonObject)
+    else functorInstance[Option, A](ev.jsonObject)(tag)
 
   implicit def mapSchema[K, V](implicit kPattern: PatternProperty[K],
                                vSchema: JsonSchema[V]): JsonSchema[Map[K, V]] =

--- a/src/main/scala/com/timeout/docless/schema/derive/HListInstances.scala
+++ b/src/main/scala/com/timeout/docless/schema/derive/HListInstances.scala
@@ -26,7 +26,7 @@ trait HListInstances {
         hSchema.asJson -> tSchema.relatedDefinitions
       else
         hSchema.asJsonRef -> (tSchema.relatedDefinitions + hSchema
-          .namedDefinition(fieldName))
+          .NamedDefinition(fieldName))
 
     val hField  = fieldName -> hValue
     val tFields = tSchema.jsonObject.toList


### PR DESCRIPTION
Amend the implementation of `JsonSchema[Option[A]]` so that:
- Json schema is inlined only if `A` is a primitive, otherwise a reference to A's definition is rendered
- the fully qualified name of A is used for the definition id instead of mistakenly using `scala.Option`